### PR TITLE
MOR-421: Not displaying error tooltip in the catalog.

### DIFF
--- a/src/components/dashboard/PreviewItem.vue
+++ b/src/components/dashboard/PreviewItem.vue
@@ -248,7 +248,7 @@ export default {
         hasError: function () {
             /** @type {BarItem} */
             var item = this.item;
-            return item.data.hasError;// && !item.data.catalogItem;
+            return item.data.hasError && !item.data.catalogItem;
         },
         /**
          * Determines how the item is displayed.


### PR DESCRIPTION
Removed the error tooltip from the button catalog.

![image](https://user-images.githubusercontent.com/1867587/108605198-9a94a700-73aa-11eb-8533-4b26ed1af58d.png)
