### PR TITLE
Getting the API URL from config

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,7 +1,9 @@
 import axios from "axios";
-import { API_URL } from "@/utils/constants";
+// Getting the API url directly from the config, rather than the constants (which depend on something that depends
+// on this file)
+import { CONFIG } from "@/config/config";
 
 export const HTTP = axios.create({
-    baseURL: API_URL,
+    baseURL: CONFIG.API_URL,
     headers: { "Content-Type": "application/json; charset=utf-8" }
 });


### PR DESCRIPTION
The url was being taken from a module, which loads another module which depends on the module that uses the url.