### PR TITLE
Creating test sites for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,34 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '## https://pr-${{ github.event.number }}.morphic.ste-test.net/\n\n${{ env.hash }}'
-            })
+            const link = `https://pr-${context.issue.number}.morphic.ste-test.net/`;
+            const commentBody = `## ${link}\n\n${process.env.hash}`;
+
+            const getComments = github.issues.listComments.endpoint.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number
+            });
+
+            const comments = await github.paginate(getComments);
+
+            const botComment = comments.find(comment => {
+                return comment.user.type === "Bot" && comment.user.login === "github-actions[bot]" && comment.body.includes(link);
+            });
+
+            const newComment = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+            };
+
+            if (botComment) {
+                newComment.comment_id = botComment.id;
+                github.issues.updateComment(newComment);
+            } else {
+                newComment.issue_number = context.issue.number;
+                github.issues.createComment(newComment);
+            }
 
       - name: Uploading build
         run: curl -v -Fbuild=@web-app.tar.gz https://build.morphic.ste-test.net/build/upload/${{ github.event.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
         run: tar -czvf web-app.tar.gz dist/
 
       - name: Getting build hash
-        run: sha256sum web-app.tar.gz | xxd -r -ps | base64 | sed 's,^,hash=,' >> $GITHUB_ENV
+        run: sha256sum web-app.tar.gz | cut -d ' ' -f 1 | xxd -r -ps | base64 | sed 's,^,hash=,' >> $GITHUB_ENV
 
       - name: Commenting
         uses: JungWinter/comment@v1.1.0
         id: comment
         with:
           type: create
-          body: "https://pr-${{ github.event.number }}.morphic.ste-test.net/\n\n${{ env.hash }}"
+          body: "# https://pr-${{ github.event.number }}.morphic.ste-test.net/\n\n${{ env.hash }}"
           issue_number: ${{ github.event.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,7 @@ jobs:
       - name: Looking for crap code
         run: npm run lint
 
-      - name: Building
-        env:
-          VUE_APP_API_URL: https://api.morphic.ste-test.net/
+      - name: Building prod
         run: npm run build
 
       - name: Packing build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,23 +17,6 @@ jobs:
         with:
           node-version: '12.x'
 
-      - name: Commenting
-        uses: JungWinter/comment@v1.1.0
-        id: comment
-        with:
-          type: create
-          body: "hello 1"
-          issue_number: ${{ github.event.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commenting
-        uses: JungWinter/comment@v1.1.0
-        with:
-          type: edit
-          body: "hello 2"
-          comment_id: ${{ steps.comment.outputs.id }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: npm install
         run: npm install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Uploading build
-        run: curl -v -Fbuild=@web-app.tar.gz https://build.morphic.ste-test.net/build/upload/$GITHUB_RUN_ID/${{ github.event.number }}
+        run: curl -v -Fbuild=@web-app.tar.gz https://build.morphic.ste-test.net/build/upload/${{ github.event.number }}
 
       - name: Archiving prod
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: check and build
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -42,6 +42,24 @@ jobs:
 
       - name: Building prod
         run: npm run build
+
+      - name: Packing build
+        run: tar -czvf web-app.tar.gz dist/
+
+      - name: Getting build hash
+        run: sha256sum web-app.tar.gz | xxd -r -ps | base64 | sed 's,^,hash=,' >> $GITHUB_ENV
+
+      - name: Commenting
+        uses: JungWinter/comment@v1.1.0
+        id: comment
+        with:
+          type: create
+          body: "https://pr-${{ github.event.number }}.morphic.ste-test.net/\n\n${{ env.hash }}"
+          issue_number: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Uploading build
+        run: curl -v -Fbuild=@web-app.tar.gz https://build.morphic.ste-test.net/build/upload/$GITHUB_RUN_ID/${{ github.event.number }}
 
       - name: Archiving prod
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,16 @@ jobs:
         run: sha256sum web-app.tar.gz | cut -d ' ' -f 1 | xxd -r -ps | base64 | sed 's,^,hash=,' >> $GITHUB_ENV
 
       - name: Commenting
-        uses: JungWinter/comment@v1.1.0
-        id: comment
+        uses: actions/github-script@v3
         with:
-          type: create
-          body: "# https://pr-${{ github.event.number }}.morphic.ste-test.net/\n\n${{ env.hash }}"
-          issue_number: ${{ github.event.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '## https://pr-${{ github.event.number }}.morphic.ste-test.net/\n\n${{ env.hash }}'
+            })
 
       - name: Uploading build
         run: curl -v -Fbuild=@web-app.tar.gz https://build.morphic.ste-test.net/build/upload/${{ github.event.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,23 @@ jobs:
         with:
           node-version: '12.x'
 
+      - name: Commenting
+        uses: JungWinter/comment@v1.1.0
+        id: comment
+        with:
+          type: create
+          body: "hello 1"
+          issue_number: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commenting
+        uses: JungWinter/comment@v1.1.0
+        with:
+          type: edit
+          body: "hello 2"
+          comment_id: ${{ steps.comment.outputs.id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: npm install
         run: npm install
 
@@ -26,17 +43,12 @@ jobs:
       - name: Building prod
         run: npm run build
 
-      - name: Building dev
-        run: npm run build-dev
-
       - name: Archiving prod
         uses: actions/upload-artifact@v2
         with:
           name: webapp-prod
           path: dist/
 
-      - name: Archiving dev
-        uses: actions/upload-artifact@v2
-        with:
-          name: webapp-dev
-          path: dev/
+
+
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Looking for crap code
         run: npm run lint
 
-      - name: Building prod
+      - name: Building
+        env:
+          VUE_APP_API_URL: https://api.morphic.ste-test.net/
         run: npm run build
 
       - name: Packing build

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -5,6 +5,9 @@ var ENV;
 if (href.host === "communitynew.morphic.dev") {
     // Hack to force the dev site to always use the dev api server.
     ENV = "DEVELOPMENT";
+} else if (href.host.match(/^pr-\d\.morphic\.ste-test\.net$/)) {
+    // A similar hack to force a test site to always use the test api server.
+    ENV = "PR_TEST";
 } else {
     ENV = process.env.NODE_ENV ? process.env.NODE_ENV.toUpperCase() : "LOCAL";
 }
@@ -14,6 +17,10 @@ const CONF = {
     LOCAL: {
         // Local development server will redirect all API requests (/v1/*) to the local API server (see vue.config.js)
         API_URL: process.env.VUE_APP_API_URL ?? new URL(location.href).origin
+    },
+    PR_TEST: {
+        // Used for testing pull requests
+        API_URL: process.env.VUE_APP_API_URL ?? "https://api.morphic.ste-test.net"
     },
     DEVELOPMENT: {
         API_URL: "https://api.morphic.dev"

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -5,7 +5,7 @@ var ENV;
 if (href.host === "communitynew.morphic.dev") {
     // Hack to force the dev site to always use the dev api server.
     ENV = "DEVELOPMENT";
-} else if (href.host.match(/^pr-\d\.morphic\.ste-test\.net$/)) {
+} else if (href.host.match(/^pr-\d+\.morphic\.ste-test\.net$/)) {
     // A similar hack to force a test site to always use the test api server.
     ENV = "PR_TEST";
 } else {


### PR DESCRIPTION
Add some steps to the github workflow to upload the build to a test server for pull requests (including when something has been pushed to an open one). The bot will add a comment with the URL.

This is so PRs can be tested in a production-like environment before being merged.
