### PR TITLE
Keeping unsaved changes to the bar.

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -57,15 +57,11 @@
 </style>
 
 <script>
-import { MESSAGES } from "@/utils/constants";
 
 export default {
     computed: {
         isLoggedIn: function () {
             return this.$store.getters.isLoggedIn;
-        },
-        disableLogout: function () {
-            return this.$store.getters.unsavedChanges;
         },
         focusedUrl: function () {
             return this.getUrl(true).href;
@@ -77,14 +73,9 @@ export default {
 
     methods: {
         logout: function () {
-            if (this.disableLogout) {
-                window.confirm(MESSAGES.logoutAlert);
-            } else {
-                this.$store.dispatch("logout")
-                    .then(() => {
-                        this.$router.push("/");
-                    });
-            }
+            this.$store.dispatch("logout").then(() => {
+                this.$router.push("/");
+            });
         },
         getBarId: function () {
             return this.$route.query.barId;

--- a/src/main.js
+++ b/src/main.js
@@ -93,6 +93,28 @@ Vue.mixin({
         },
 
         /**
+         * Displays a modal dialog, resolving when the dialog is dismissed.
+         * @param {String} modalId The id of the modal dialog.
+         * @return {Promise<String>} Resolves with the trigger value of the modal's hide event.
+         */
+        showModalDialog(modalId) {
+            return new Promise((resolve, reject) => {
+
+                const onHide = (event, id) => {
+                    if (id === modalId) {
+                        resolve(event.trigger);
+                        this.$root.$off("bv::modal::hide", onHide);
+                    }
+                };
+
+                this.$root.$on("bv::modal::hide", onHide);
+
+                this.$bvModal.show(modalId);
+            });
+
+        },
+
+        /**
          * Gets the url of an icon
          * @param {String} image The icon identified (from image_url)
          * @return {String} The url.

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -16,7 +16,7 @@ export default new Vuex.Store({
         community: {},
         errorMessage: {},
         unsavedChanges: false,
-        unsavedBar: {},
+        unsavedBar: JSON.parse(localStorage.getItem("unsavedBar") || "null"),
         resetPasswordEmail: ""
     },
     mutations: {
@@ -171,6 +171,11 @@ export default new Vuex.Store({
             commit("unsavedChanges", isChanged);
         },
         unsavedBar({ commit }, barDetails) {
+            if (barDetails) {
+                localStorage.setItem("unsavedBar", JSON.stringify(barDetails));
+            } else {
+                localStorage.removeItem("unsavedBar");
+            }
             commit("unsavedBar", barDetails);
         }
     },

--- a/src/utils/bar.js
+++ b/src/utils/bar.js
@@ -13,6 +13,23 @@ export function getItemBar(barItem) {
 }
 
 /**
+ * Gets a friendly name of a bar.
+ * @param {BarDetails} bar The bar.
+ * @return {String} Name of the bar.
+ */
+export function getBarName(bar) {
+    var name;
+    if (bar.name === "Default") {
+        name = "Default Bar";
+    } else if (bar.is_shared) {
+        name = bar.name;
+    } else {
+        name = `Bar for ${bar.name}`;
+    }
+    return name;
+}
+
+/**
  * Gets the index of a bar item in a bar.
  * @param {BarItem} barItem The item to add (either from the catalog, or the service.
  * @param {BarDetails} [bar] The bar.

--- a/src/views/focused/FocusedHome.vue
+++ b/src/views/focused/FocusedHome.vue
@@ -63,7 +63,6 @@
 </style>
 
 <script>
-import { MESSAGES } from "@/utils/constants";
 import { getCommunityBars, getCommunity, getCommunityMembers } from "@/services/communityService";
 import * as Bar from "@/utils/bar";
 
@@ -107,14 +106,9 @@ export default {
     },
     methods: {
         logout: function () {
-            if (this.disableLogout) {
-                window.confirm(MESSAGES.logoutAlert);
-            } else {
-                this.$store.dispatch("logout")
-                    .then(() => {
-                        this.$router.push("/");
-                    });
-            }
+            this.$store.dispatch("logout").then(() => {
+                this.$router.push("/");
+            });
         },
         loadData: function () {
             return new Promise((resolve, reject) => {


### PR DESCRIPTION
Reloading unsaved changes after the user logs out, session expires, or closes the page.

The unsaved changes will re-appear when the user comes back to the bar. If the user starts to edit a different bar, then they will be asked about the unsaved changes:

![image](https://user-images.githubusercontent.com/1867587/111009083-8e3cb200-838a-11eb-9e67-10abb898035f.png)

If the user is editing a bar, and tries to leave the page, they will be asked about it:

![image](https://user-images.githubusercontent.com/1867587/111009115-a44a7280-838a-11eb-9d50-ace273659714.png)

Also, the user is now free to log out, without being forced to save their changes (they're automatically stored)
