### PR TITLE
Removing the stored bar when dismissing the unsaved changes dialog

### DIFF
--- a/src/views/MorphicBarEditor.vue
+++ b/src/views/MorphicBarEditor.vue
@@ -1503,6 +1503,12 @@ export default {
                 }
             }
 
+            if (nextPage) {
+                // Discard the current bar, if moving to another page.
+                this.isChanged = false;
+                this.storeUnsavedBar();
+            }
+
             return nextPage;
         }
     },


### PR DESCRIPTION
Makes the unsaved changes dialog work better.