### PR TITLE
NO-JIRA: Reserving space for the validation error message.

### DIFF
--- a/src/components/ValidatedInput.vue
+++ b/src/components/ValidatedInput.vue
@@ -32,6 +32,10 @@
 
       <template #description>
         <span v-if="description">{{description}}</span>
+        <!-- Reserves space for the validation error, to stop fields below being nudged down -->
+        <div v-if="state !== false" class="invalid-feedback invalid-feedback-reserved" aria-hidden="true">
+          <span>.</span>
+        </div>
       </template>
 
     </b-form-group>
@@ -58,6 +62,11 @@
 }
 .invalid-feedback span {
   font-size: 0.9rem;
+}
+
+.invalid-feedback-reserved {
+  display: block !important;
+  visibility: hidden;
 }
 
 button.showPasswordButton {


### PR DESCRIPTION
Validation error messages were causing the fields below to move down.

![Peek 2021-04-05 20-24](https://user-images.githubusercontent.com/1867587/113618236-4a6a5f00-964f-11eb-8ff4-fff275f84111.gif)

The space is now reserved:

![Peek 2021-04-05 20-40](https://user-images.githubusercontent.com/1867587/113618268-56eeb780-964f-11eb-88e4-7ffadd13ba68.gif)
