### PR TITLE
Disabling re-selection of an item's sites or app after it was created.

### DIFF
--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -16,6 +16,7 @@
  * @property {String} editItemField The field of the item, in the edit dialog.
  * @property {String} selectionText Text for the drop-down field when no item is selected
  * @property {String} selectionError Error message if an item has not been selected.
+ * @property {Boolean} allowReselection true to allow the app/link to be changed after it was created.
  * @property {String} kind The kind of all items (undefined if any differ)
  * @property {Boolean} related True if the items are related (shows the group tab in the edit dialog)
  * @property {Boolean} hasSecondary True there are secondary items in the group (item.is_primary is false)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -117,6 +117,7 @@ export const buttonCatalog = {
     make: {
         title: "Make a button",
         editTitle: "Custom Button",
+        allowReselection: true,
         defaultIcon: undefined,
         related: false
     },
@@ -221,7 +222,8 @@ export const buttonCatalog = {
         title: "Local Apps",
         hidden: true,
         editTitle: "Start an Application",
-        editItemField: "App"
+        editItemField: "App",
+        allowReselection: true
     }
 };
 

--- a/src/views/EditButtonDialog.vue
+++ b/src/views/EditButtonDialog.vue
@@ -25,7 +25,9 @@
                             >
 
                 <div class="relatedSelection">
-                  <b-dropdown variant="light"
+
+                  <b-dropdown v-if="buttonGroup.allowReselection || wasPlaceholder"
+                              variant="light"
                               ref="RelatedDropdown"
                               id="relatedDropdown"
                               menu-class=""
@@ -59,6 +61,12 @@
                   </template>
 
                   </b-dropdown>
+                  <template v-else>
+                    <b-img v-if="relatedButtons[button.data.buttonKey].configuration.image_url" :src="getIconUrl(relatedButtons[button.data.buttonKey].configuration.image_url)" :alt="relatedButtons[button.data.buttonKey].configuration.label + ' logo'" />
+                    {{
+                      relatedButtons[button.data.buttonKey].data.catalogLabel || relatedButtons[button.data.buttonKey].configuration.label
+                    }}
+                  </template>
                 </div>
 
               </b-form-group>
@@ -155,7 +163,7 @@
     overflow-y: auto;
     position: fixed !important;
   }
-  button img {
+  img {
     margin-right: 0.5em;
     width: 32px;
     height: 32px;
@@ -272,7 +280,10 @@ export default {
 
             fieldChanged: 0,
 
-            relatedDropdownStyle: null
+            relatedDropdownStyle: null,
+
+            /** @type {Boolean} true if the bar item was a placeholder when it was opened */
+            wasPlaceholder: false
 
         };
     },
@@ -468,6 +479,7 @@ export default {
         showDialog: function (selectedItem) {
             this.selectedItem = selectedItem;
             this.button = JSON.parse(JSON.stringify(this.selectedItem));
+            this.wasPlaceholder = this.button.data.isPlaceholder;
 
             this.buttonGroup = buttonCatalog[this.button.configuration.subkind];
             this.dialogTitle = this.buttonGroup.editTitle;


### PR DESCRIPTION
The site/app for a button can't be changed (only when first adding a "More xyz Sites..." placeholder from the catalog)

![image](https://user-images.githubusercontent.com/1867587/116061009-4774f400-a67a-11eb-878c-ded3f2ea4bce.png)
