### PR TITLE
URL validation fixes

### DIFF
--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -633,16 +633,6 @@ export async function checkUrl(urlToCheck = "", timeout = 10000) {
                 error = "Link is not a website address";
             }
 
-            // See if the link is already in the button catalog - assume these to be always working.
-            isKnown = Object.values(constants.allButtons).some((b) => {
-                let result;
-                if (b.configuration.url?.includes(urlParsed.hostname)) {
-                    const u = new URL(b.configuration.url);
-                    result = (u.hostname === urlParsed.hostname || u.hostname === `www.${urlParsed.hostname}`) && u.pathname === urlParsed.pathname;
-                }
-                return result;
-            });
-
             if (isKnown) {
                 togo = {};
             }

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -625,18 +625,12 @@ export async function checkUrl(urlToCheck = "", timeout = 10000) {
     } else {
         let urlParsed;
         let error;
-        let isKnown;
 
         try {
             urlParsed = new URL(url);
             if (!urlParsed || (urlParsed.protocol !== "https:" && urlParsed.protocol !== "http:")) {
                 error = "Link is not a website address";
             }
-
-            if (isKnown) {
-                togo = {};
-            }
-
         } catch {
             error = "Link does not look valid";
         }
@@ -647,7 +641,7 @@ export async function checkUrl(urlToCheck = "", timeout = 10000) {
                 alert: "Broken link",
                 message: error
             });
-        } else if (!isKnown) {
+        } else {
             const cancelSource = axios.CancelToken.source();
 
             let requestUrl;

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -591,12 +591,13 @@ export function checkForProblems(button, paramKey, live) {
 
 /**
  * Checks if a url is working.
- * @param {String} url The url
+ * @param {String} urlToCheck The url
  * @param {Number} [timeout] milliseconds to wait [default: 10000].
  * @return {Promise<CheckResult>} Resolves when done.
  */
-export async function checkUrl(url = "", timeout = 10000) {
+export async function checkUrl(urlToCheck = "", timeout = 10000) {
     let togo;
+    const url = urlToCheck.trim();
 
     if (!url.startsWith("http://") && !url.startsWith("https://")) {
         // Try https
@@ -669,7 +670,9 @@ export async function checkUrl(url = "", timeout = 10000) {
             };
 
             togo = client.head(requestUrl, req).then(value => {
-                return {};
+                return {
+                    newValue: url !== urlToCheck ? url : undefined
+                };
             }).catch(reason => {
                 reason.handled = true;
                 return {


### PR DESCRIPTION
* Trims whitespace from the url field
* Assumes urls found in the button catalog are working, and don't check them

Related: https://github.com/raisingthefloor/morphic-api-server/pull/113
