### PR TITLE
Bar expands fully with content

### DIFF
--- a/src/components/editor/DesktopBarEditor.vue
+++ b/src/components/editor/DesktopBarEditor.vue
@@ -181,7 +181,6 @@
         justify-content: flex-start;
         align-content: flex-start;
 
-        max-width: 400px;
         // Hide the drawer by limiting the width
         &:not(.showDrawer) {
           width: 120px !important;


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/1867587/120661991-acddb100-c480-11eb-8a26-7cf5cf4684f1.png)
