### PR TITLE
Button catalog more accessible

### DIFF
--- a/src/components/dashboard/PreviewItem.vue
+++ b/src/components/dashboard/PreviewItem.vue
@@ -1,5 +1,6 @@
 <template>
-  <b-link class="previewItem" id="previewItemButton"
+  <b-link class="previewItem" role="button"
+          :disabled="disabled"
           :class="[buttonClass, {broken: hasError}]"
           v-b-tooltip="{title: 'This button has an issue. Click for more information', placement: 'left', variant: 'warning', disabled: !hasError}"
            :to="linkTo"
@@ -229,7 +230,8 @@ export default {
         item: Object,
         simplified: Boolean,
         noImage: Boolean,
-        to: Object
+        to: Object,
+        disabled: Boolean
     },
     data() {
         return {

--- a/src/components/dashboard/PreviewItem.vue
+++ b/src/components/dashboard/PreviewItem.vue
@@ -11,11 +11,11 @@
     <template v-if="buttonClass === 'simplified'">
       <div v-if="item.data.visual && item.data.visual.type === 'multiButton'" class="multiButton">
         <div class="buttons" style="margin-top: 5px;">
-          <button v-for="(button, index) in item.data.visual.buttons" v-bind:key="index"
+          <span v-for="(button, index) in item.data.visual.buttons" v-bind:key="index"
                   class="rounded multiButton"
                   :style="'background: '+colors.default_button"
                   v-bind:class="{ 'extraBig': item.data.visual.extraBig}">
-          </button>
+          </span>
         </div>
       </div>
       <div v-else-if="noImage" class="noImage" :style="'background: '+colors.default_button">
@@ -34,7 +34,7 @@
         <button v-for="(button, index) in item.data.visual.buttons" v-bind:key="index"
                 :style="'background: '+colors.default_button + '; background-color: ' + (item.configuration.color || colors.default_button) + ';'"
                 v-bind:class="{ 'extraBig': item.data.visual.extraBig}"
-              tabindex="-1">
+                tabindex="-1">
           {{ button }}
         </button>
       </div>

--- a/src/components/editor/ButtonCatalog.vue
+++ b/src/components/editor/ButtonCatalog.vue
@@ -55,8 +55,6 @@
                     :style="{order: button.searchResult && button.searchResult.order}"
                     :title="button.configuration.description"
                     :ref="'catalog_' + buttonId"
-
-                      @x-keypress.enter="isLite || onItemSelected(button)"
                 >
                   <!-- Render each button as draggable -->
                   <drag :data="button" type="catalogButtonWithImage" :disabled="isLite">


### PR DESCRIPTION
Improved the a18y for the button catalog:

- Made the items reveal when they are selected, instead of replace
- Removed the phantom tab sink
- Removed the buttons inside links