### PR TITLE
Removed catalog disclosure

### DIFF
--- a/src/components/dashboard/PreviewItem.vue
+++ b/src/components/dashboard/PreviewItem.vue
@@ -10,11 +10,11 @@
     <template v-if="buttonClass === 'simplified'">
       <div v-if="item.data.visual && item.data.visual.type === 'multiButton'" class="multiButton">
         <div class="buttons" style="margin-top: 5px;">
-          <button v-for="(button, index) in item.data.visual.buttons" v-bind:key="index"
+          <span v-for="(button, index) in item.data.visual.buttons" v-bind:key="index"
                   class="rounded multiButton"
                   :style="'background: '+colors.default_button"
                   v-bind:class="{ 'extraBig': item.data.visual.extraBig}">
-          </button>
+          </span>
         </div>
       </div>
       <div v-else-if="noImage" class="noImage" :style="'background: '+colors.default_button">
@@ -33,7 +33,7 @@
         <button v-for="(button, index) in item.data.visual.buttons" v-bind:key="index"
                 :style="'background: '+colors.default_button + '; background-color: ' + (item.configuration.color || colors.default_button) + ';'"
                 v-bind:class="{ 'extraBig': item.data.visual.extraBig}"
-              tabindex="-1">
+                tabindex="-1">
           {{ button }}
         </button>
       </div>

--- a/src/components/dashboard/PreviewItem.vue
+++ b/src/components/dashboard/PreviewItem.vue
@@ -1,6 +1,7 @@
 <template>
   <b-link class="previewItem" id="previewItemButton"
           :class="[buttonClass, {broken: hasError}]"
+          :disabled="disabled"
           v-b-tooltip="{title: 'This button has an issue. Click for more information', placement: 'left', variant: 'warning', disabled: !hasError}"
            :to="linkTo"
           @click="$emit('click', {data: item})"
@@ -229,7 +230,8 @@ export default {
         item: Object,
         simplified: Boolean,
         noImage: Boolean,
-        to: Object
+        to: Object,
+        disabled: Boolean
     },
     data() {
         return {

--- a/src/components/editor/ButtonCatalog.vue
+++ b/src/components/editor/ButtonCatalog.vue
@@ -61,7 +61,7 @@
                   <drag :data="button" type="catalogButtonWithImage" :disabled="isLite">
                     <!-- Define looks when dragged -->
                     <template v-slot:drag-image>
-                      <PreviewItem :item="button" :noImage="false" xclass="noImage"/>
+                      <PreviewItem :item="button" disabled :noImage="false" />
                     </template>
 
                     <!-- Define looks when not selected -->

--- a/src/components/editor/ButtonCatalog.vue
+++ b/src/components/editor/ButtonCatalog.vue
@@ -63,7 +63,7 @@
                     </template>
 
                     <b-button variant="link"
-                              @click="onItemSelected(button)"
+                              @click="onItemSelected(button, $event.altKey)"
                               :style="'color: ' + (button.configuration.color || colors.blue) + ';'"
                               class="buttonCatalogEntry nonExpandedCatalogEntry">
                       <div class="imageWrapper" :class="{expanderIcon:button.data.isExpander}">

--- a/src/components/editor/ButtonCatalog.vue
+++ b/src/components/editor/ButtonCatalog.vue
@@ -54,8 +54,6 @@
                     :style="{order: button.searchResult && button.searchResult.order}"
                     :title="button.configuration.description"
                     :ref="'catalog_' + buttonId"
-                    tabindex="-1"
-                      @keypress.enter="isLite || onItemSelected(button)"
                 >
                   <!-- Render each button as draggable -->
                   <drag :data="button" type="catalogButtonWithImage" :disabled="isLite">
@@ -64,10 +62,8 @@
                       <PreviewItem :item="button" disabled :noImage="false" />
                     </template>
 
-                    <!-- Define looks when not selected -->
-                    <b-button v-if="buttonId !== expandedCatalogButtonId"
-                              variant="link"
-                              @click="expandCatalogButton(button, buttonId, subkind)"
+                    <b-button variant="link"
+                              @click="onItemSelected(button)"
                               :style="'color: ' + (button.configuration.color || colors.blue) + ';'"
                               class="buttonCatalogEntry nonExpandedCatalogEntry">
                       <div class="imageWrapper" :class="{expanderIcon:button.data.isExpander}">
@@ -84,44 +80,6 @@
                       <span v-html="getCatalogItemLabel(button, buttonGroup.searchWords)" />
                     </b-button>
 
-                    <!-- Define looks when selected (expanded) -->
-                    <div v-else class="active" @click="expandedCatalogButtonId = undefined"
-                    >
-                      <div style="width: 100%; display: inline-flex; align-items: center;">
-                        <b-img v-if="button.configuration.image_url" :src="getIconUrl(button.configuration.image_url)"
-                               style="width: 20px; height: 20px; max-width: 20px; max-height: 20px;"/>
-                        <b-img v-else :src="'/icons/bootstrap.svg'"
-                               style="width: 20px; height: 20px; max-width: 20px; max-height: 20px;"></b-img>
-                        <h3 style="margin-block-start: inherit; text-decoration-line: underline; margin-left: 0.5rem; margin-bottom: 0.05rem;">
-                          {{button.configuration.label}}</h3>
-                      </div>
-                      <div class="description">{{button.configuration.description || "A button that enables the functionality described above"}}
-                      </div>
-                      <div class="help">To add this button, press ENTER, RETURN, or drag button below onto the bar</div>
-                      <div class="buttons"
-                           @click="$event.stopPropagation()"
-                      >
-                        <drag :data="button" type="catalogButtonNoImage" :disabled="isLite">
-                          <PreviewItem :item="button"
-                                       :simplified="true" :noImage="true"
-                                       class="noImage"
-                                             @click="onItemSelected(button, true)"
-                          />
-                        </drag>
-
-                        <drag v-if="button.kind !== 'action'" :data="button" type="catalogButtonWithImage" :disabled="isLite">
-                          <template v-slot:drag-image>
-                            <PreviewItem :item="button" :noImage="false" class="noImage"
-                                               @click="onItemSelected(button, true)"
-                            />
-                          </template>
-                          <PreviewItem v-if="button.configuration.image_url"
-                                       :item="button" :simplified="true" class="withImage"
-                                             @click="onItemSelected(button)"
-                          />
-                        </drag>
-                      </div>
-                    </div>
                   </drag>
                 </li>
               </template>
@@ -237,55 +195,18 @@
               display: none;
             }
           }
-
-          .active {
-            background-color: #e0f1d7;
-            border: solid 1px #008145;
-            border-radius: 5px;
-            padding: 10px;
-
-            .buttons {
-              display: flex;
-              justify-content: space-around;
-              align-items: flex-end;
-            }
-
-            h3 {
-              margin-top: 15px;
-              font-size: 20px;
-              margin-bottom: 0px;
-            }
-
-            div.description {
-              font-size: 14px;
-            }
-
-            div.help {
-              font-size: 14px;
-              font-weight: bold;
-              margin-top: 15px;
-              line-height: 18px;
-            }
-          }
         }
       }
     }
 
-    .nonExpandedCatalogEntry {
+    .buttonCatalogEntry {
       width: 100%;
       display: block;
 
       img, svg {
         max-width: 16px;
         width: 16px;
-        max-width: 16px;
-        width: 16px;
         display: inline-block;
-      }
-
-      .buttonCatalogEntry {
-        width: 100%;
-        display: block;
       }
     }
   }
@@ -318,7 +239,6 @@ export default {
     data() {
         return {
             colors: colors,
-            expandedCatalogButtonId: undefined,
 
             /**
              * Catalog search text
@@ -352,20 +272,6 @@ export default {
                 item: item,
                 noImage: !!noImage
             });
-        },
-        expandCatalogButton: function (button, buttonId, subkind) {
-            if (!button) {
-                this.expandedCatalogButtonId = undefined;
-                this.expandedCatalogButton = undefined;
-            } else if (button.data.isExpander) {
-                this.showSecondaryItems(subkind);
-                this.expandedCatalogButtonId = undefined;
-                this.expandedCatalogButton = undefined;
-            } else {
-                this.expandedCatalogButtonId = buttonId;
-                this.expandedCatalogButton = button;
-                this.$refs["catalog_" + buttonId][0].focus();
-            }
         },
 
         /**
@@ -445,7 +351,6 @@ export default {
     },
     watch: {
         searchText: function () {
-            this.expandCatalogButton(null);
             this.searchCatalog();
         }
     }

--- a/src/views/MorphicBarEditor.vue
+++ b/src/views/MorphicBarEditor.vue
@@ -153,7 +153,6 @@ export default {
 
             // close the catalog
             this.showCatalog(false);
-            this.$refs.ButtonCatalog.expandCatalogButton(null);
             this.onBarChanged();
 
             let showEdit;

--- a/src/views/MorphicBarEditor.vue
+++ b/src/views/MorphicBarEditor.vue
@@ -313,13 +313,17 @@ export default {
         showCatalog: function (show) {
             const catalogRoute = {...this.$route };
             catalogRoute.query = {...catalogRoute.query };
+            const lastValue = catalogRoute.query.catalogView;
+
             if (show) {
                 catalogRoute.query.catalogView = true;
             } else {
                 delete catalogRoute.query.catalogView;
             }
 
-            this.$router.push(catalogRoute);
+            if (lastValue !== catalogRoute.query.catalogView) {
+                this.$router.push(catalogRoute);
+            }
 
             this.$refs.ButtonCatalog.$el.focus();
 
@@ -381,11 +385,15 @@ export default {
         },
         /**
          * Confirms if the user wants to leave the page, if there have been unsaved changes
+         * @param {Route} to The target route.
+         * @param {Route} from The current route.
          * @return {Promise<Boolean>} Resolves with true to move to the next page.
          */
-        leavePage: async function () {
+        leavePage: async function (to, from) {
             var nextPage = true;
-            if (this.isChanged) {
+            const sameBar = (to.query.barId === from.query.barId && to.query.memberId === from.query.memberId);
+
+            if (!sameBar && this.isChanged) {
                 const dialogResult = await this.showModalDialog("unsavedChanges");
 
                 switch (dialogResult) {
@@ -502,11 +510,11 @@ export default {
         }
     },
     async beforeRouteUpdate(to, from, next) {
-        const proceed = this.$store.getters.isLoggedIn ? await this.leavePage() : true;
+        const proceed = this.$store.getters.isLoggedIn ? await this.leavePage(to, from) : true;
         next(proceed);
     },
     async beforeRouteLeave(to, from, next) {
-        const proceed = this.$store.getters.isLoggedIn ? await this.leavePage() : true;
+        const proceed = this.$store.getters.isLoggedIn ? await this.leavePage(to, from) : true;
         next(proceed);
     },
     beforeUpdate() {


### PR DESCRIPTION
Button catalog items no longer expand - just clicking an item adds it to the bar (dragging still works)

From [ SPEC - Morphic Plus Customization WebApp
](https://docs.google.com/document/d/1l2u3Jn3liOXZFlWl9YIX33IyA_-jOZ0Fm1WlUtL0nwQ/edit#heading=h.sbtyqo7gwzfo)

At _"Dashboard/Standard view changes 2021-05-24"_:

> 4. Remove the “information about this button” stage from the button list names in the button catalog 
> a. (i.e., currently, when a person clicks an element, a disclosure area with information about the button opens up.  This would be removed.).
> b. This also removes the navy placeholder buttons
> 
> 5. Thus, clicking (or activating with a keyboard) an element in the button catalog, adds the default version of the button immediately to the end of the list of buttons in the bar/drawer.
> The default version of the button is the one with an icon, where an icon is available.
> 
> 6. Option-clicking (Alt-clicking) an element in the button catalog adds the non-icon version immediately to the end of the list of buttons in the bar/drawer
> 
> 
