### PR TITLE
Always checking the bar for errors when something has changed

### DIFF
--- a/src/components/editor/DesktopBarEditor.vue
+++ b/src/components/editor/DesktopBarEditor.vue
@@ -20,7 +20,7 @@
 
       <!-- Bar item problems -->
       <div class="desktop-alerts">
-        <b-alert v-for="(error) in barDetails.errors"
+        <b-alert v-for="(error) in barWarnings"
                  :key="error.key"
                  show
                  variant="warning"
@@ -314,6 +314,7 @@ import { Drag, Drop, DropList } from "vue-easy-dnd";
 import BarItemLink from "@/components/editor/BarItemLink";
 import PreviewItem from "@/components/dashboard/PreviewItem";
 import Arrow from "@/components/Arrow";
+import * as Bar from "@/utils/bar";
 
 export default {
     name: "DesktopBarEditor",
@@ -326,6 +327,7 @@ export default {
         DropList
     },
     props: {
+        /** @type {BarDetails} */
         barDetails: {},
         isChanged: Boolean
     },
@@ -334,6 +336,12 @@ export default {
             openDrawer: true,
             dragInProgress: false
         };
+    },
+    computed: {
+        barWarnings: function () {
+            Bar.checkBar(this.barDetails);
+            return this.barDetails.errors;
+        }
     },
     methods: {
         /**


### PR DESCRIPTION
Stops the warning about not selecting an app, when an app has been selected.