### PR TITLE
Fixed new item not being removed when dismissing the dialog

### DIFF
--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -2,7 +2,7 @@
   <b-modal id="modalEditGeneric"
            ref="EditDialog"
            v-bind="dialogAttrs"
-           @ok="okClicked" @cancel="closeDialog(false)" @hide="onHide"
+           @ok="okClicked" @hide="onHide" @cancel="closeDialog(false)"  @close="closeDialog(false)"
            size="lg"
            :title="dialogTitle">
 
@@ -621,6 +621,8 @@ export default {
                 this.removeButton();
                 // removeButton() will close the dialog, if required.
                 e.preventDefault();
+            } else if (e.trigger === "esc") {
+                this.closeDialog(false);
             }
         },
         /**


### PR DESCRIPTION
Dismissing the dialog shown when adding a new item always cancels the new item, unless *save* is clicked.