### PR TITLE
Button editor: button customisation area

### DIFF
--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -120,11 +120,11 @@
                 <!-- icon selection -->
                 <div class="buttonIcons" aria-live="polite">
                   <div class="actionButtons">
-                    <b-button variant="invert-morphic-blue"
+                    <b-button variant="primary"
                               size="sm"
                               :disabled="!selectedIcon && !showImages"
                               @click="selectedIcon = null, showImages = false">Remove button image</b-button>
-                    <b-button variant="invert-morphic-blue"
+                    <b-button variant="primary"
                               size="sm"
                               :disabled="showImages"
                               @click="showImages = true">{{ selectedIcon ? "Change button image" : "Add button image"}}</b-button>

--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -102,8 +102,7 @@
               >
 
                 <!-- colour selection -->
-                <b-form-group label="Color for button"
-                              label-for="ColorSelection">
+                <b-form-group label="Color for button">
                   <b-form-radio-group id="ColorSelection"
                                       class="colorSelection"
                                       v-model="button.configuration.color"
@@ -111,8 +110,8 @@
                     <b-form-radio v-for="(hex, name) in colors"
                                   :key="name"
                                   :value="hex"
-                                  class="customRadio colorRadio">
-                      <span class="screenReader">{{name}}</span>
+                                  class="customRadio colorRadio" :aria-labelledby="`${name}_label`">
+                      <span class="screenReader" :id="`${name}_label`">{{name}}</span>
                       <div class="colorBlock" :style="'background-color: ' + hex + ';'" />
                     </b-form-radio>
                   </b-form-radio-group>

--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -740,7 +740,7 @@ export default {
          * Removes this button from the bar.
          */
         removeButton: function () {
-            this.showConfirm("Do you want to remove this item from the bar?").then(result => {
+            this.showConfirm("Do you want to remove this item from the bar?", null, `Delete the '${this.selectedItem.configuration.label}' button`, {dangerous: true}).then(result => {
                 if (result) {
                     Bar.removeItem(this.selectedItem, this.bar);
                     this.selectedItem.deleted = true;

--- a/src/main.js
+++ b/src/main.js
@@ -133,11 +133,15 @@ Vue.mixin({
                 : message.split("\n");
             const messageNodes = lines.map(line => this.$createElement("p", {}, line));
 
+            const dangerous = options && options.dangerous;
+
             return this.$bvModal.msgBoxConfirm(messageNodes, Object.assign({
                 title: title,
                 okTitle: (buttons && buttons[0]) || "Yes",
                 cancelTitle: (buttons && buttons[1]) || "No",
-                centered: true
+                centered: true,
+                autoFocusButton: dangerous ? "cancel" : "ok",
+                okVariant: dangerous && "danger"
             }, options));
         },
 

--- a/src/mixins/members.js
+++ b/src/mixins/members.js
@@ -24,7 +24,10 @@ export const membersMixin = {
                         this.$t("members.delete.apply_button", {member: member.displayName}),
                         this.$t("members.delete.cancel_button")
                     ],
-                    this.$t("members.delete.title"));
+                    this.$t("members.delete.title"),
+                    {
+                        dangerous: true
+                    });
 
             const req = confirmed && communityService.deleteCommunityMember(this.communityId, member.id);
             return req && this.requestToBool(req, MESSAGES.successfulMemberDelete).then(success => {
@@ -90,7 +93,7 @@ export const membersMixin = {
                     [this.$t("members.removeBar.apply_button"), this.$t("members.removeBar.cancel_button")],
                     bar.name,
                     {
-                        okVariant: "danger"
+                        dangerous: true
                     });
 
             var togo;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -188,7 +188,7 @@ export const buttonCatalog = {
     news: {
         title: "News",
         editTitle: "News Site",
-        defaultIcon: "newspaper",
+        defaultIcon: "news$newspaper",
         more: {
             description: "Create a button to open a news web-site"
         }

--- a/src/views/MyCommunity.vue
+++ b/src/views/MyCommunity.vue
@@ -294,7 +294,7 @@ export default {
                     ["Remove", "Cancel"],
                     `Remove '${member.fullName}' as group manager`,
                     {
-                        okVariant: "danger"
+                        dangerous: true
                     });
                 confirm.then(result => {
                     if (result) {


### PR DESCRIPTION
Part of the **July Redesign 2021-07-27** section of  [SPEC - Morphic Plus Customization WebApp](https://docs.google.com/document/d/1l2u3Jn3liOXZFlWl9YIX33IyA_-jOZ0Fm1WlUtL0nwQ/edit#heading=h.esdbh646ce9q)

## Style of dialog buttons for button image

* Changed the colour of the Remove/Change image buttons
* Fixed the broken image for news sites
* A11Y improvements:
  * Labelled the Color radio buttons
  * Focusing the *No* button on the delete confirmation dialog

![image](https://user-images.githubusercontent.com/1867587/128570707-cb1fe9fd-4a83-41db-86ff-388bb37e9e46.png)
