### PR TITLE
Making the drop-down more accessible

### DIFF
--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -47,7 +47,10 @@
                   >
                     <template #button-content>
                       <template v-if="!button.data.isPlaceholder">
-                        <b-img v-if="relatedButtons[button.data.buttonKey].configuration.image_url" :src="getIconUrl(relatedButtons[button.data.buttonKey].configuration.image_url)" :alt="relatedButtons[button.data.buttonKey].configuration.label + ' logo'" />
+                        <b-img v-if="relatedButtons[button.data.buttonKey].configuration.image_url"
+                               :src="getIconUrl(relatedButtons[button.data.buttonKey].configuration.image_url)"
+                               aria-hidden="true"
+                               alt="" />
                         {{
                           relatedButtons[button.data.buttonKey].data.catalogLabel || relatedButtons[button.data.buttonKey].configuration.label
                         }}
@@ -66,6 +69,7 @@
                                               :class="{ selected: buttonKey === button.data.buttonKey }"
                       >
                       <b-img v-if="item.configuration.image_url" :src="getIconUrl(item.configuration.image_url)"
+                             aria-hidden="true"
                              alt="" />{{ item.data.catalogLabel || item.configuration.label }}
                       </b-dropdown-item-button>
                   </template>

--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -43,6 +43,7 @@
                               boundary="viewport"
                               @show="relatedDropdown(true)"
                               @hidden="relatedDropdown(false)"
+                              @shown="relatedDropdownFocusSelected()"
                   >
                     <template #button-content>
                       <template v-if="!button.data.isPlaceholder">
@@ -57,12 +58,12 @@
                     </template>
 
 
-                    <template v-for="(item, buttonKey) in relatedButtons"
-                              :class="buttonKey === button.data.buttonKey && 'selected'">
+                    <template v-for="(item, buttonKey) in relatedButtons">
 
                       <b-dropdown-item-button v-if="!item.data.isPlaceholder"
                                               :key="buttonKey"
                                               @click="setButton(item)"
+                                              :class="{ selected: buttonKey === button.data.buttonKey }"
                       >
                       <b-img v-if="item.configuration.image_url" :src="getIconUrl(item.configuration.image_url)"
                              alt="" />{{ item.data.catalogLabel || item.configuration.label }}
@@ -682,6 +683,16 @@ export default {
         },
 
         /**
+         * Focus the selected item on the drop-down.
+         */
+        relatedDropdownFocusSelected: function () {
+            const selected = document.querySelector("#relatedDropdown .dropdown-menu .selected .dropdown-item");
+            if (selected) {
+                selected.focus();
+            }
+        },
+
+        /**
          * Shows a message of problems.
          * @return {Promise<Boolean>} true to continue with saving.
          */
@@ -711,7 +722,6 @@ export default {
 
             this.fixFavicon();
             this.$bvModal.show("modalEditGeneric");
-
 
             setTimeout(() => {
                 this.a11yWrapDropdown(this.$refs.RelatedDropdown);

--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -714,6 +714,9 @@ export default {
 
 
             setTimeout(() => {
+                this.a11yWrapDropdown(this.$refs.RelatedDropdown);
+                this.a11yDropdownMnemonics(this.$refs.RelatedDropdown);
+
                 // The drop-down doesn't support autofocus.
                 if (this.showRelated && this.button.data.isPlaceholder) {
                     document.querySelector("#relatedDropdown button").focus();

--- a/src/components/editor/EditButtonDialog.vue
+++ b/src/components/editor/EditButtonDialog.vue
@@ -365,6 +365,7 @@ import * as Bar from "@/utils/bar";
 import BarItemFields from "@/components/editor/BarItemFields";
 import { CONFIG } from "@/config/config";
 import { dialogMixin } from "@/mixins/dialog.js";
+import { a11yMixin } from "@/mixins/a11y";
 
 export default {
     name: "EditButtonDialog",
@@ -373,7 +374,7 @@ export default {
         bar: Object
     },
 
-    mixins: [dialogMixin],
+    mixins: [dialogMixin, a11yMixin],
 
     components: {
         BarItemFields,

--- a/src/mixins/a11y.js
+++ b/src/mixins/a11y.js
@@ -37,6 +37,14 @@ export const a11yMixin = {
                 return undefined;
             }
 
+            // Focus the first item, if there's nothing focused already
+            dropdown.$on("shown", function (e) {
+                const hasSelection = dropdown.$el.querySelector("ul.dropdown-menu .dropdown-item:focus");
+                if (!hasSelection) {
+                    dropdown.focusItem(0, dropdown.getItems());
+                }
+            });
+
             const elem = dropdown.$el.querySelector("ul.dropdown-menu");
 
             elem.addEventListener("keydown", (event) => {

--- a/src/mixins/a11y.js
+++ b/src/mixins/a11y.js
@@ -1,0 +1,52 @@
+/**
+ * Mix-in for accessibility helpers.
+ * @type {Component}
+ */
+export const a11yMixin = {
+    methods: {
+        /**
+         * Make a drop-down support focus wrapping.
+         *
+         * @param {BDropdown} dropdown The b-dropdown component.
+         */
+        a11yWrapDropdown: function (dropdown) {
+            if (dropdown.focusNext.orig) {
+                return;
+            }
+            const orig = dropdown.focusNext;
+
+            dropdown.focusNext = (event, up) => {
+                const items = dropdown.getItems();
+                const index = items.indexOf(event.target);
+
+                // When attempting to move beyond the limit, wrap the next focus by faking the selected item to the
+                // one after/before the item at other end, and change the direction, before calling the real
+                // focusNext().
+                let newTarget;
+                if (up && index === 0) {
+                    newTarget = items[items.length - 2];
+                } else if (!up && index >= items.length - 1) {
+                    newTarget = items[1];
+                }
+
+                if (newTarget) {
+                    // Create a dummy event object - this is all focusNext() requires.
+                    const e = {
+                        target: newTarget,
+                        stopPropagation() {
+                            event.stopPropagation();
+                        },
+                        preventDefault() {
+                            event.preventDefault();
+                        }
+                    };
+                    dropdown.focusNext.orig(e, !up);
+                } else {
+                    dropdown.focusNext.orig(event, up);
+                }
+            };
+
+            dropdown.focusNext.orig = orig;
+        }
+    }
+};

--- a/src/mixins/a11y.js
+++ b/src/mixins/a11y.js
@@ -5,6 +5,84 @@
 export const a11yMixin = {
     methods: {
         /**
+         * Provides mnemonic support for dropdowns.
+         * @param {VueComponent} dropdown The drop-down component.
+         */
+        a11yDropdownMnemonics: function (dropdown) {
+            if (dropdown.a11yDropdownMnemonics) {
+                return;
+            }
+
+            /**
+             * Starting at a given index, find the first item that begins with the text, then wrap to the start.
+             * @param {Array<HTMLElement>} items The list of items.
+             * @param {String} text The text to find.
+             * @param {Number} startIndex The index from which to start.
+             * @return {HTMLElement?} The item found.
+             */
+            function findNext(items, text, startIndex = 0) {
+                const match = (item) => item.innerText.toLowerCase().startsWith(text);
+
+                for (let index = startIndex; index < items.length; index++) {
+                    if (match(items[index])) {
+                        return items[index];
+                    }
+                }
+                for (let index = 0; index < startIndex; index++) {
+                    if (match(items[index])) {
+                        return items[index];
+                    }
+                }
+
+                return undefined;
+            }
+
+            const elem = dropdown.$el.querySelector("ul.dropdown-menu");
+
+            elem.addEventListener("keydown", (event) => {
+                if (event.ctrlKey || event.altKey || event.key.length !== 1) {
+                    return;
+                }
+                const timeout = 5000;
+                const lastTime = dropdown.mnemonics_lastTime;
+                dropdown.mnemonics_lastTime = event.timeStamp;
+
+                /** @type {Array<HTMLElement>} */
+                const items = dropdown.getItems();
+                const selectedIndex = items.indexOf(event.target);
+
+                // Reset the search string if after the timeout, or the selection has changed since last time.
+                if (dropdown.mnemonics_text === undefined ||
+                    !lastTime || event.timeStamp - lastTime > timeout ||
+                    selectedIndex !== dropdown.mnemonics_last) {
+                    dropdown.mnemonics_text = "";
+                }
+
+                // Append the key character to the search string.
+                const key = event.key.toLowerCase();
+                dropdown.mnemonics_text += key;
+
+                // Find the next matching item.
+                let found = findNext(items, dropdown.mnemonics_text, selectedIndex);
+                if (!found) {
+                    found = findNext(items, key, selectedIndex + 1);
+                    if (found) {
+                        dropdown.mnemonics_text = key;
+                    }
+                }
+
+                if (found) {
+                    const index = items.indexOf(found);
+                    dropdown.focusItem(index, items);
+                    dropdown.mnemonics_last = index;
+                } else {
+                    dropdown.mnemonics_last = selectedIndex;
+                }
+
+            });
+        },
+
+        /**
          * Make a drop-down support focus wrapping.
          *
          * @param {BDropdown} dropdown The b-dropdown component.


### PR DESCRIPTION
Improved the drop-down list in the button customisation dialog:

* Selection wrapping: Using the arrow button when at either end of the list will wrap the selection around
* If something is already selected, it will be focused in the drop-down
* Mnemonics - items can be jumped to by typing letter(s):
  * `I` moves to *Imgur*
  * `I` again moves to *Instagram*
  * `T` moves to *Tumblr*,
  * `W` moves to *Twitter* (from `TW`)

![Peek 2021-08-06 22-33](https://user-images.githubusercontent.com/1867587/128573295-01f6d76c-8acf-4bab-87f6-c0ccf92c4618.gif)
