### PR TITLE
Removed error alerts when adding a new item

### DIFF
--- a/src/components/editor/BarItemFields.vue
+++ b/src/components/editor/BarItemFields.vue
@@ -74,25 +74,14 @@ export default {
         autofocus: Boolean
     },
     data() {
-        const states = {};
-        const errors = {};
-        const checking = {};
-        this.barItem.data.paramFields.forEach(paramKey => {
-            const problem = params.getProblem(this.barItem, paramKey);
-            const err = problem && problem.message;
-            errors[paramKey] = err;
-            states[paramKey] = err ? false : null;
-            checking[paramKey] = false;
-        });
-
         return {
             allParameters: params.allParameters,
             /** @type {Object<String,Boolean?>} */
-            validationStates: states,
+            validationStates: {},
             /** @type {Object<String,String>} */
-            validationErrors: errors,
+            validationErrors: {},
             checkTimers: {},
-            isChecking: checking,
+            isChecking: {},
             lastValues: {}
         };
     },
@@ -202,6 +191,18 @@ export default {
             }
         }
 
+    },
+    mounted() {
+        // Show any problems associated with the fields.
+        this.barItem.data.paramFields.forEach(paramKey => {
+            const problem = params.getProblem(this.barItem, paramKey);
+            console.log(paramKey, problem);
+            const err = problem && problem.message;
+            this.validationErrors[paramKey] = err;
+            this.validationStates[paramKey] = err ? false : null;
+            this.isChecking[paramKey] = false;
+        });
+        this.$forceUpdate();
     },
     beforeDestroy() {
         this.clearCheckTimer();

--- a/src/components/editor/ButtonCatalog.vue
+++ b/src/components/editor/ButtonCatalog.vue
@@ -60,7 +60,7 @@
                     :class="{
                               noImage: !button.configuration.image_url && !button.data.isExpander,
                               secondaryItem: !button.is_primary,
-                              expander: button.data.isExpander,
+                              expander: button.data.isExpander
                           }"
                     :style="{order: button.searchResult && button.searchResult.order}"
                     :aria-details="button.configuration.description"

--- a/src/components/editor/DesktopBarEditor.vue
+++ b/src/components/editor/DesktopBarEditor.vue
@@ -99,7 +99,13 @@
                   @click="showEditDialog(item, $event)"
                   @cut="removeButton(item, barDetails.items)"
                   class="buttonDragger">
-              <div :key="item.id" class="previewHolder" :ref="buttonRef(item)">
+              <div :key="item.id"
+                   :class="{
+                     previewHolder: true,
+                     newItem: item.data.isNew
+                   }"
+                   :ref="buttonRef(item)"
+              >
                 <PreviewItem :item="item" />
               </div>
             </drag>
@@ -263,6 +269,10 @@
 
         & > div {
           min-width: 50px;
+        }
+
+        .newItem {
+          opacity: 0.4;
         }
 
         // Place-holder for dropping a new button.

--- a/src/jsdoc.js
+++ b/src/jsdoc.js
@@ -70,6 +70,8 @@
  * @property {String} catalogLabel Label in the catalog (if different to `label`).
  * @property {String} category Category in the catalog
  * @property {Boolean} [hasError] true if one of the parameter values has a validation error.
+ * @property {Boolean} isNew true if the item has been just added from the catalog, before the customisation dialog has
+ *  been displayed.
  * @property {Object<String,String>} parameters Values of the named parameters used in fields.
  * @property {Array<String>} paramFields The field names of this object which are parameterised.
  * @property {Object<String,ItemProblem>} problems Results of the last problem check.


### PR DESCRIPTION
Removes the error announcement before the customisation dialog is shown, when adding a new item.

Also, the new item is faded on the bar, to show it's not fully added yet.

![image](https://user-images.githubusercontent.com/1867587/128697936-f8752ab8-31ec-44d5-bd1b-edb08079188d.png)
