### PR TITLE
General screen-reader related improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,10 @@
       <h1 v-if="heading" id="MainHeading" :class="{screenReader: hideHeading}">{{ heading }}</h1>
       <router-view />
     </div>
+    <div class="screenReader">
+      <div id="ScreenReaderAnnouncements" aria-live="polite"></div>
+      <div id="ScreenReaderAnnouncementsAssertive" aria-live="assertive"></div>
+    </div>
     <Footer />
   </b-container>
 </template>
@@ -46,7 +50,7 @@
     overflow: hidden;
     width: 1px;
     height: 1px;
-    clip: rect(1px, 1px, 1px, 1px);
+    clip: rect(0, 0, 0, 0);
   }
 </style>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -135,9 +135,23 @@ export default {
                 document.body.classList.remove(...remove);
                 document.body.classList.add(...add);
             }
+        },
+        "$route.path": function (newValue, oldValue) {
+            this.newPage();
         }
     },
     methods: {
+        /**
+         * A new page has been loaded.
+         */
+        newPage: function () {
+            // When a new page is loaded, announce the title and move focus to the skip to content link.
+            this.screenReaderMessage(this.$route.meta.title);
+            const skipLink = document.getElementById("SkipToContent");
+            if (skipLink) {
+                skipLink.focus();
+            }
+        },
         /**
          * Set the local of the page.
          * @param {String} locale Identifier of the locale.

--- a/src/App.vue
+++ b/src/App.vue
@@ -149,6 +149,9 @@ export default {
             this.screenReaderMessage(this.$route.meta.title);
             const skipLink = document.getElementById("SkipToContent");
             if (skipLink) {
+                // Don't show the link, until the next time it's focused.
+                skipLink.classList.add("screenReader");
+                skipLink.addEventListener("blur", () => skipLink.classList.remove("screenReader"), {once: true});
                 skipLink.focus();
             }
         },

--- a/src/App.vue
+++ b/src/App.vue
@@ -119,6 +119,13 @@ export default {
 
         this.getHeaderHeight();
         this.dialogScroll();
+
+        // For screen-readers, having a footer on a dialog is not desired.
+        this.$root.$on("bv::modal::shown", (bvEvent, modalId) => {
+            document.querySelectorAll("footer.modal-footer").forEach(elem => {
+                elem.setAttribute("role", "presentation");
+            });
+        });
     },
     watch: {
         bodyClasses: {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,9 +4,10 @@
       <a class="contentLink" id="SkipToContent" href="#PageContent" @click.prevent="skipToContent">Skip to content</a>
       <b-navbar-brand>
         <b-link to="/">
-          <img src="/img/logo-color.svg" class="logo" alt="Return to dashboard" />
+          <img src="/img/logo-color.svg" class="logo" :alt="$t('Header.product-name')" />
         </b-link>
         <span class="headerTitle"
+              aria-hidden="true"
               v-t="'Header.product-name'" />
       </b-navbar-brand>
     </header>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,13 +1,15 @@
 <template>
   <b-navbar toggleable="md" type="light" variant="light" id="top" ref="nav" tag="div" role="banner">
-    <a class="contentLink" href="#PageContent" @click.prevent="skipToContent">Skip to content</a>
-    <b-navbar-brand>
-      <b-link to="/">
-        <img src="/img/logo-color.svg" class="logo" alt="Return to dashboard" />
-      </b-link>
-      <span class="headerTitle"
-            v-t="'Header.product-name'" />
-    </b-navbar-brand>
+    <header>
+      <a class="contentLink" id="SkipToContent" href="#PageContent" @click.prevent="skipToContent">Skip to content</a>
+      <b-navbar-brand>
+        <b-link to="/">
+          <img src="/img/logo-color.svg" class="logo" alt="Return to dashboard" />
+        </b-link>
+        <span class="headerTitle"
+              v-t="'Header.product-name'" />
+      </b-navbar-brand>
+    </header>
 
     <template v-if="isLoggedIn">
       <b-navbar-toggle target="nav-actions" ref="navToggle"/>
@@ -60,7 +62,7 @@
         transition: transform 250ms ease-out;
       }
 
-      &:focus {
+      &:focus-visible {
         transform: translateX(0);
       }
     }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -15,8 +15,8 @@
     <template v-if="isLoggedIn">
       <b-navbar-toggle target="nav-actions" ref="navToggle"/>
       <b-collapse id="nav-actions" is-nav v-model="showMenu">
-        <b-navbar-nav v-if="isLoggedIn" class="ml-auto loggedInNav">
-          <b-nav-text>
+        <b-navbar-nav class="ml-auto loggedInNav" :role="isMobile && 'presentation'">
+          <b-nav-text v-if="!isMobile">
             <b-button v-if="focusMode && !isMobile"
                       variant="invert-dark"
                       @click="showMenu = false; setFocusMode(false)" v-t="'Header.standard-mode_button'" />
@@ -32,7 +32,7 @@
       </b-collapse>
     </template>
 
-    <b-navbar-nav v-else-if="$route.name !== 'Login'" class="ml-auto loggedOutNav">
+    <b-navbar-nav v-else-if="$route.name !== 'Login'" class="ml-auto loggedOutNav" role="presentation">
       <b-nav-text>
         <b-button variant="invert-dark" :to="{name: 'Login'}"><b-icon icon="box-arrow-left"/> {{ $t('Header.login_button') }}</b-button>
       </b-nav-text>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -63,7 +63,7 @@
         transition: transform 250ms ease-out;
       }
 
-      &:focus-visible {
+      &:not(.screenReader):focus-visible {
         transform: translateX(0);
       }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -100,9 +100,25 @@ Vue.mixin({
         /**
          * Presents a message only visible to screen readers.
          * @param {String} message The message.
+         * @param {Boolean} assertive true for messages which require immediate attention.
          */
-        screenReaderMessage(message) {
-            this.showMessage(message, undefined, {toastClass: "screenReader"});
+        screenReaderMessage(message, assertive) {
+            // Add a full-stop to separate it from the next message.
+            if (!message.endsWith(".")) {
+                message += ".";
+            }
+
+            // Create a new element containing the message.
+            const newMessage = document.createElement("span");
+            newMessage.setAttribute("aria-atomic", "true");
+            newMessage.appendChild(document.createTextNode(message));
+
+            // Add it to the DOM
+            const readerElem = document.getElementById(assertive ? "ScreenReaderAnnouncementsAssertive" : "ScreenReaderAnnouncements");
+            readerElem.appendChild(newMessage);
+
+            // Remove it later.
+            setTimeout(() => newMessage.remove(), 5000);
         },
 
         showError(message, title, options) {

--- a/src/main.js
+++ b/src/main.js
@@ -273,6 +273,18 @@ Vue.mixin({
                 }
                 return success;
             }).catch(() => false);
+        },
+
+        /**
+         * Remove the built-in aria-label attributes from all icons, unless aria-hidden has been explicitly set.
+         * If a label requires an aria-label, then set the aria-hidden attribute to false.
+         */
+        removeIconLabels: function () {
+            if (this.$el.querySelectorAll) {
+                this.$el.querySelectorAll("svg[aria-label]:not([aria-hidden])").forEach(e => {
+                    e.removeAttribute("aria-label");
+                });
+            }
         }
     },
     mounted() {
@@ -282,12 +294,10 @@ Vue.mixin({
         // Apply the production-only condition
         document.body.classList.toggle("production", this.CONFIG.PRODUCTION);
 
-        // Remove the redundant aria-label attributes from all icons, unless aria-hidden has been explicitly set.
-        if (this.$el.querySelectorAll) {
-            this.$el.querySelectorAll("svg[aria-label]:not([aria-hidden])").forEach(e => {
-                e.removeAttribute("aria-label");
-            });
-        }
+        this.removeIconLabels();
+    },
+    updated() {
+        this.removeIconLabels();
     },
     computed: {
         isLoggedIn: function () { return this.$store.getters.isLoggedIn; },

--- a/src/views/MorphicBarEditor.vue
+++ b/src/views/MorphicBarEditor.vue
@@ -204,10 +204,17 @@ export default {
             }
         },
 
-        loadAllData: function () {
-            this.loadBarData();
-            this.loadBarMembers();
-            this.getCommunityData();
+        /**
+         * Loads the required data for the page.
+         */
+        loadAllData: async function () {
+            await Promise.all([
+                this.getCommunityData(),
+                this.loadBarData(),
+                this.loadBarMembers()
+            ]);
+
+            this.screenReaderMessage(`Now editing bar '${this.barDetails.name}', owned by '${this.memberDetails.displayName}`);
         },
 
         /** Loads the initial bar data */
@@ -217,6 +224,7 @@ export default {
             // If there is a bar unsaved, redirect to that one instead.
             /** @type {BarDetails} */
             const unsavedBar = this.$store.getters.unsavedBar;
+
             if (unsavedBar && unsavedBar.id !== barId) {
                 const barName = Bar.getBarName(unsavedBar);
                 const message = `There is already a bar (${barName}) that has unsaved changes. The recent changes will be lost if you continue.`;
@@ -230,7 +238,7 @@ export default {
 
                 if (!ok) {
                     this.$router.push(this.getBarEditRoute(unsavedBar));
-                    return;
+                    throw new Error("Not loading");
                 }
             }
 
@@ -241,14 +249,8 @@ export default {
                 this.isChanged = false;
                 this.storeUnsavedBar();
                 // Load a saved bar.
-                getCommunityBar(this.communityId, barId)
-                    .then(resp => {
-                        this.barDetails = resp.data;
-                        this.updateOriginalBarDetails();
-                    })
-                    .catch(err => {
-                        console.error(err);
-                    });
+                this.barDetails = (await getCommunityBar(this.communityId, barId)).data;
+                this.updateOriginalBarDetails();
             }
         },
         // hack to refresh css rendering due to bars being fucked up in their CSS
@@ -347,31 +349,29 @@ export default {
 
         },
 
-        loadBarMembers: function () {
-            getCommunityBars(this.communityId)
-                .then(resp => {
-                    const barsData = resp.data.bars;
-                    getCommunityMembers(this.communityId)
-                        .then((resp) => {
-                            this.barsList = barsData;
-                            this.membersList = resp.data.members;
-                        })
-                        .catch(err => {
-                            console.error(err);
-                        });
-                })
-                .catch(err => {
-                    console.error(err);
-                });
+        /**
+         * Loads the bars and members
+         * @return {Promise} Resolves when complete.
+         */
+        loadBarMembers: async function () {
+            const barsResponse = getCommunityBars(this.communityId);
+            const membersResponse = getCommunityMembers(this.communityId);
+
+            const bars = await barsResponse;
+            const members = await membersResponse;
+            this.barsList = bars.data.bars;
+            this.membersList = members.data.members;
+            return true;
         },
+
+        /**
+         * Loads the community data.
+         * @return {Promise} Resolves when complete.
+         */
         getCommunityData: function () {
-            getCommunity(this.communityId)
-                .then((community) => {
-                    this.community = community.data;
-                })
-                .catch(err => {
-                    console.error(err);
-                });
+            return getCommunity(this.communityId).then((community) => {
+                this.community = community.data;
+            });
         },
         /**
          * Update the filtered arrays of bars.


### PR DESCRIPTION
- Announcing page titles on new pages, and focusing the invisible *Skip to Content* link.
- Moved the site name onto the logo `alt` text.
- Removing the labels from more icons.
- Removed `footer` tags from all dialogs.
- Not using a list on the top menu, when only a single item.