### PR TITLE
Redirecting non-managers to the subscription page.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -228,7 +228,7 @@ router.beforeEach((to, from, next) => {
                 // redirect back to the page visited before login
                 redirect = store.getters.beforeLoginPage;
                 store.commit("beforeLoginPage", undefined);
-            } else if (!store.getters.hasAccount) {
+            } else if (!store.getters.hasAccount || !store.getters.isManager) {
                 // no account - tell them to get one.
                 redirect = {name: "NoSubscription"};
             } else {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,6 +12,7 @@ export default new Vuex.Store({
         token: localStorage.getItem("token") || "",
         userId: localStorage.getItem("userId") || "",
         communityId: localStorage.getItem("communityId") || "",
+        role: "",
         user: {},
         community: {},
         errorMessage: {},
@@ -63,6 +64,9 @@ export default new Vuex.Store({
         },
         community(state, communityId) {
             state.communityId = communityId;
+        },
+        role(state, role) {
+            state.role = role;
         },
         unsavedChanges(state, isChanged) {
             state.unsavedChanges = isChanged;
@@ -172,6 +176,7 @@ export default new Vuex.Store({
                         if (communities.length !== 0) {
                             localStorage.setItem("communityId", communities[0].id);
                             commit("community", communities[0].id);
+                            commit("role", communities[0].role);
                             resolve(communities);
                         } else {
                             reject(new Error("User doesn't have communities."));
@@ -214,6 +219,8 @@ export default new Vuex.Store({
         authStatus: state => state.status,
         userId: state => state.userId,
         communityId: state => state.communityId,
+        role: state => state.role,
+        isManager: state => state.role === "manager",
         hasAccount: state => !!state.communityId,
         unsavedChanges: state => state.unsavedChanges,
         /** @type {BarDetails} */


### PR DESCRIPTION
When a non-manager community member logs in, they're redirected to this page:

![image](https://user-images.githubusercontent.com/1867587/129548880-071867bb-83b3-4d7d-8bde-c90466f5512e.png)
