### PR TITLE
Checking if the session token is still active, for every page load

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -214,6 +214,11 @@ const authHomeRoute = routes.find(r => r.meta.authHome);
 const homeRoute = routes.find(r => r.meta.home);
 
 router.beforeEach((to, from, next) => {
+    if (store.getters.isLoggedIn) {
+        // Refresh the user's community info. The side-effect of this is to check if the current session token is still
+        // active.
+        store.dispatch("userCommunities", store.getters.userId).catch(() => undefined);
+    }
 
     // Merge the route meta data
     /** @type {RouteMeta} */


### PR DESCRIPTION
People were getting redirected to the No Subscription page, despite being logged out.

Looking at the code, there's no plausible way for this to happen. However, perhaps the front-end thought it was still logged in, but really the session had expired.

