### PR TITLE
Invitation flow: email verification

### DIFF
--- a/public/email.html
+++ b/public/email.html
@@ -15,8 +15,12 @@
     // Email link, Learn more about morphic
     learnMore: "https://morphic.org",
     // Email link, for managers to help users get setup.
-    helpSetup: "https://morphic.org"
+    helpSetup: "https://morphic.org",
+    download: "https://morphic.org/notify/",
+    downloadMac: "https://morphic.org/help/installation-for-macos/",
+    downloadWin: "https://morphic.org/help/installation-for-windows/"
 };
+
 
 
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -21,6 +21,8 @@ if (href.host.endsWith(".morphic.dev")) {
  * @property {Boolean} DISABLE_FAVICONS true to disable the use of favicons in buttons.
  * @property {Boolean} DISABLE_TRIAL true to ignore any trial checking - hide the banner.
  * @property {Number} MAX_BARS Number of bars a member can have, before hiding the add bar button.
+ * @property {Number} MAC_VERSION Lowest macOS version supported
+ * @property {Number} WIN_VERSION Lowest Windows version supported
  */
 
 /**
@@ -33,7 +35,9 @@ const CONF = {
         PRODUCTION: false,
         RECAPTCHA_SITEKEY: "6LcDs3waAAAAAFGKPHxnNuPBO__5LqaEybnS6wn0",
         DISABLE_TRIAL: true,
-        MAX_BARS: 5
+        MAX_BARS: 5,
+        MAC_VERSION: 10.14,
+        WIN_VERSION: 10
     },
 
     // Local development (npm run dev)

--- a/src/config/externalLinks.js
+++ b/src/config/externalLinks.js
@@ -7,5 +7,8 @@ export default {
     // Email link, Learn more about morphic
     learnMore: "https://morphic.org",
     // Email link, for managers to help users get setup.
-    helpSetup: "https://morphic.org"
+    helpSetup: "https://morphic.org",
+    download: "https://morphic.org/notify/",
+    downloadMac: "https://morphic.org/help/installation-for-macos/",
+    downloadWin: "https://morphic.org/help/installation-for-windows/"
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,6 +6,11 @@
   "ButtonCatalog": {
     "search-result-summary": "No items found | 1 item found | {n} items found"
   },
+  "ConfirmEmail": {
+    "dialog_title": "Confirm your email",
+    "loading": "Loading...",
+    "ok_button": "Resend email"
+  },
   "CopyBarDialog": {
     "confirm-dialog": {
       "no_button": "@:(General.no_button)",

--- a/src/main.js
+++ b/src/main.js
@@ -57,21 +57,23 @@ Vue.mixin({
          * @param {Error} err The error object.
          */
         handleServerError(err) {
-            if (this.errorMessage !== undefined && this.errorAlert !== undefined) {
-                err.handled = true;
-                const message = this.getErrorMessage(err, true);
-                this.errorMessage = message.message;
-                if (this.errorMessageTitle !== undefined) {
-                    this.errorMessageTitle = message.title;
+            if (!err.handled) {
+                if (this.errorMessage !== undefined && this.errorAlert !== undefined) {
+                    err.handled = true;
+                    const message = this.getErrorMessage(err, true);
+                    this.errorMessage = message.message;
+                    if (this.errorMessageTitle !== undefined) {
+                        this.errorMessageTitle = message.title;
+                    }
+                    this.errorAlert = true;
                 }
-                this.errorAlert = true;
-            }
 
-            // Get the autofocus input, or just the first one.
-            const elem = this.$el && this.$el.querySelector ? this.$el : document.getElementById(this.dialogId);
-            const f = elem.querySelector("input.autofocus") || elem.querySelector("input");
-            if (f && f.focus) {
-                f.focus();
+                // Get the autofocus input, or just the first one.
+                const elem = this.$el && this.$el.querySelector ? this.$el : document.getElementById(this.dialogId);
+                const f = elem.querySelector("input.autofocus") || elem.querySelector("input");
+                if (f && f.focus) {
+                    f.focus();
+                }
             }
         },
         /**

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,6 +23,7 @@ import MorphicBarPreconfigured from "@/views/MorphicBarPreconfigured.vue";
 import MorphicBarEditor from "@/views/MorphicBarEditor.vue";
 
 import RegistrationInvite from "@/views/RegistrationInvite";
+import ConfirmEmail from "@/views/email/ConfirmEmail.vue";
 
 // Email call-backs
 import AcceptInvite from "@/views/email/AcceptInvite.vue";
@@ -218,6 +219,25 @@ const routes = [
             public: "only"
         }
     },
+    {
+        path: "/confirm-email",
+        name: "ConfirmEmail",
+        component: ConfirmEmail,
+        meta: {
+            title: "Confirm your email address"
+        }
+    },
+    {
+        path: "/confirm-email/sign-in",
+        name: "ConfirmEmail.SignIn",
+        component: ConfirmEmail,
+        props: {
+            signIn: true
+        },
+        meta: {
+            title: "Confirm your email address"
+        }
+    },
     // Email call-backs
     {
         path: "/invite/:action/:id/:page",
@@ -226,6 +246,16 @@ const routes = [
         props: true,
         meta: {
             title: "Invitation to Morphic",
+            public: true
+        }
+    },
+    {
+        path: "/confirm-email/:confirmUserId/:token",
+        name: "Email.Confirm",
+        component: ConfirmEmail,
+        props: true,
+        meta: {
+            title: "Confirm email address",
             public: true
         }
     }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -179,7 +179,8 @@ const routes = [
         component: Dashboard,
         meta: {
             title: "Home: MorphicBar Customization Tool",
-            authHome: true
+            authHome: true,
+            roles: ["manager"]
         }
     },
     {
@@ -198,7 +199,8 @@ const routes = [
         meta: {
             title: "MorphicBar Editor",
             hideHeading: true,
-            isEditorPage: true
+            isEditorPage: true,
+            roles: ["manager"]
         }
     },
     {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -223,7 +223,7 @@ const routes = [
     },
     {
         path: "/confirm-email",
-        name: "ConfirmEmail",
+        name: "ConfirmEmail.Registered",
         component: ConfirmEmail,
         meta: {
             title: "Confirm your email address"

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,6 +28,8 @@ import ConfirmEmail from "@/views/email/ConfirmEmail.vue";
 // Email call-backs
 import AcceptInvite from "@/views/email/AcceptInvite.vue";
 
+import Download from "@/views/Download";
+
 Vue.use(VueRouter);
 
 /**
@@ -243,6 +245,28 @@ const routes = [
         },
         meta: {
             title: "Confirm your email address"
+        }
+    },
+    {
+        path: "/download",
+        name: "Download",
+        component: Download,
+        props: {
+        },
+        meta: {
+            title: "Download Morphic"
+        }
+    },
+    {
+        // Download page, when coming from the invitation flow.
+        path: "/download/invited",
+        name: "Download.Invited",
+        component: Download,
+        props: {
+            invited: true
+        },
+        meta: {
+            title: "Download Morphic"
         }
     },
     // Email call-backs

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -222,14 +222,19 @@ const routes = [
         }
     },
     {
-        path: "/confirm-email",
+        // Confirming email - from the registration page.
+        path: "/confirm-email/registered",
         name: "ConfirmEmail.Registered",
         component: ConfirmEmail,
+        props: {
+            registered: true
+        },
         meta: {
             title: "Confirm your email address"
         }
     },
     {
+        // Confirming email - after sign-in.
         path: "/confirm-email/sign-in",
         name: "ConfirmEmail.SignIn",
         component: ConfirmEmail,

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -23,6 +23,16 @@ export function resetPassword(body) {
     return HTTP.post("/v1/auth/username/password_reset/request", body, {action: "reset password"});
 }
 
+export function getUser(userId) {
+    return HTTP.get(`/v1/users/${userId}`, {action: "get user details"}).then(r => r.data);
+}
+export function confirmEmail(userId, token) {
+    return HTTP.post(`/v1/users/${userId}/verify_email/${token}`, {}, {action: "confirm email"});
+}
+export function resendEmailConfirmation(userId) {
+    return HTTP.post(`/v1/users/${userId}/resend_verification`, {}, {action: "resend email confirmation"});
+}
+
 
 /**
  * Gets the details of an invitation.

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -144,7 +144,6 @@ export default new Vuex.Store({
                 localStorage.removeItem("role");
                 localStorage.removeItem("email");
                 delete HTTP.defaults.headers.common.Authorization;
-                window.location.href = "/#/";
                 resolve();
             });
         },

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -1,0 +1,134 @@
+<!-- Link to the download page -->
+<template>
+  <b-card class="downloadCard" title="Download Morphic">
+    <p>
+      If you haven't downloaded and installed the Morphic app, you can now download Morphic to your computer(s).
+      Morphic works on Windows 10 (v2004 or newer) and macOS (10.14 Mojave or newer).<br/>
+      If your computer has one of these operating systems - the download for that OS will show up below. (If you don't know what
+      version you have you can try to install Morphic. It will tell you if your computer does not qualify.
+    </p>
+
+    <div v-if="osNotSupported">
+      Your current device does not appear to be compatible with Morphic. To run Morphic, you will need to run it on a
+      computer with Windows 10 or Mac (Mojave or better). Try updating your operating system. Both Windows and macOS
+      have free updates to new versions.
+    </div>
+    <div v-else class="d-flex flex-column align-items-center">
+      <b-link v-if="isMac || !osKnown"
+              :href="externalLinks.downloadMac"
+
+              class="btn btn-lg btn-primary m-3"
+      >Download Morphic for Mac</b-link>
+      <b-link v-if="isWindows || !osKnown"
+              :href="externalLinks.downloadWin"
+
+              class="btn btn-lg btn-primary m-3"
+      >Download Morphic for Windows</b-link>
+    </div>
+
+    <p>
+    After downloading Morphic, you will need to install it on your computer.
+    </p>
+
+    <h3>Need help?</h3>
+    <p>
+    If you need help downloading or installing Morphic, try contacting the person who invited you. They might be able to
+    help walk you through the steps. Their contact information is in the Morphic invitation email you got earlier.
+    </p>
+
+    <b-link :href="externalLinks.download">Support link with all available Morphic version downloads</b-link>.
+
+
+  </b-card>
+</template>
+
+<style lang="scss">
+
+body:not(.isMobile) #ConfirmEmailDialog {
+  pointer-events: none;
+  & > * {
+    pointer-events: auto;
+  }
+}
+
+.downloadCard {
+  width: fit-content;
+  max-width: 780px;
+  margin: 5em auto;
+}
+
+</style>
+
+<script>
+
+
+import { CONFIG } from "@/config/config";
+
+export default {
+    name: "Download",
+    components: {},
+    data() {
+        return {
+            /** @type {Boolean} */
+            isWindows: false,
+            /** @type {Boolean} */
+            isMac: false,
+            /** @type {String?} */
+            osVersion: null,
+            /** @type {Boolean?} */
+            osNotSupported: null
+        };
+    },
+    props: {
+    },
+    async mounted() {
+        this.loaded = false;
+        this.detectOS();
+        this.loaded = true;
+    },
+    computed: {
+        /**
+         * Determines if the OS is known.
+         * @return {Boolean} true if the OS is either Windows or Mac (and not both).
+         */
+        osKnown: function () {
+            return !!(this.isWindows ^ this.isMac);
+        },
+        forceOS: function () {
+            return this.$route.query.os;
+        }
+    },
+    methods: {
+        detectOS: function () {
+            // Containing Mac or Win should be enough.
+            const platform = this.forceOS || navigator.platform;
+            this.isMac = !!platform.match(/Mac/i);
+            this.isWindows = !!platform.match(/Win/i);
+
+            // Check the version
+            if (this.osKnown) {
+                let minVer;
+                if (this.isMac) {
+                    const m = navigator.userAgent.match(/OS X (1[0-9._]+)/);
+                    this.osVersion = m && m[1].replace(/_/g, ".");
+                    minVer = CONFIG.MAC_VERSION;
+                } else if (this.isWindows) {
+                    const m = navigator.userAgent.match(/Windows NT ([1-9][0-9._]*)/);
+                    this.osVersion = m && m[1];
+                    minVer = CONFIG.WIN_VERSION;
+                }
+
+                if (minVer) {
+                    this.osNotSupported = this.osVersion && parseFloat(this.osVersion) < minVer;
+                }
+            } else {
+                // Consumer devices that are definitely unsupported (chrome, ipad, iphone, android)
+                if (navigator.userAgent.match(/^Mozilla\/5.0 \([^)]*\b(CrOS|iP(hone|ad)|Android)\b/)) {
+                    this.osNotSupported = true;
+                }
+            }
+            console.log(navigator.platform, navigator.userAgent);
+        }
+    }
+};
+</script>

--- a/src/views/email/AcceptInvite.vue
+++ b/src/views/email/AcceptInvite.vue
@@ -12,7 +12,8 @@
         <span v-else-if="accepted" v-t="'Invite.message-accepted'" />
         </p>
         <template #footer>
-          <div class="d-flex justify-content-around">
+          <b-button v-if="isLoggedIn" variant="primary" to="/" class="alignRight pl-4 pr-4" v-t="'General.ok_button'" />
+          <div v-else class="d-flex justify-content-around">
             <b-button variant="primary" :href="externalLinks.morphicHome" v-t="'Invite.home-page_button'" />
             <b-button variant="primary" to="/"><b-icon icon="box-arrow-in-right"/>{{ $t('Invite.sign-in_button') }}</b-button>
           </div>
@@ -218,7 +219,9 @@ export default {
             const success = await this.formComponent.onSubmit(true);
             if (success) {
                 await acceptCommunityMemberInvite(this.invitation.communityId, this.invitation.invitationId);
-                this.state = "accepted";
+
+                // Go to email confirmation
+                this.$router.push({name: "ConfirmEmail.Registered"});
             }
             return success;
         }

--- a/src/views/email/ConfirmEmail.vue
+++ b/src/views/email/ConfirmEmail.vue
@@ -60,14 +60,14 @@
         <template #info>
           <p id="EmailSteps">If you didn't get an email from Morphic, here are some steps you can try:</p>
           <ul aria-describedby="EmailSteps">
-            <li>Wait a couple of minues to the email to arrive.</li>
+            <li>Wait a couple of minutes to the email to arrive.</li>
             <li>Check your junk or spam folder.</li>
             <li>Go back and check your email address.</li>
             <li>Press the "Resend email" button to get another copy.</li>
           </ul>
 
           <div class="text-center p-3">
-            <b-button variant="invert-dark" class="pl-4 pr-4">Resend Email</b-button>
+            <b-button variant="invert-dark" class="pl-4 pr-4" @click="resendEmail()">Resend Email</b-button>
           </div>
 
         </template>
@@ -97,7 +97,7 @@ body:not(.isMobile) #ConfirmEmailDialog {
 <script>
 
 import TwoColumnDialog from "@/components/dialogs/TwoColumnDialog";
-import { confirmEmail, getUser } from "@/services/userService";
+import { confirmEmail, getUser, resendEmailConfirmation } from "@/services/userService";
 
 export default {
     name: "ConfirmEmail",
@@ -212,6 +212,15 @@ export default {
                     this.checkTimer = setTimeout(() => this.waitForConfirmation(), 5000);
                 }
             }
+
+            return togo;
+        },
+
+        /**
+         * Re-sends the confirmation email.
+         */
+        resendEmail: function () {
+            resendEmailConfirmation(this.userId).then(() => this.showMessage("Re-sent your confirmation email"));
         }
     }
 };

--- a/src/views/email/ConfirmEmail.vue
+++ b/src/views/email/ConfirmEmail.vue
@@ -115,7 +115,10 @@ export default {
         };
     },
     props: {
+        // Accessed during sign in.
         signIn: Boolean,
+        // Accessed after registration.
+        registered: Boolean,
         confirmUserId: String,
         token: String
     },
@@ -154,8 +157,18 @@ export default {
             } else {
                 this.confirmed = true;
             }
+        } else if (!this.isLoggedIn) {
+            this.$router.replace({name: "Home"});
         } else {
             await this.waitForConfirmation();
+
+            if (this.confirmed) {
+                if (this.registered) {
+                    this.$router.replace({name: "Download"});
+                } else {
+                    this.$router.replace({name: "Home"});
+                }
+            }
         }
 
         this.loaded = true;
@@ -179,7 +192,7 @@ export default {
 
         /**
          * Starts a timer that polls the confirmation state.
-         * @return {Promise<void>}
+         * @return {Promise<Boolean?>} Resolves with the current confirmation state.
          */
         waitForConfirmation: async function () {
             if (this.checkTimer === "here") {
@@ -190,8 +203,10 @@ export default {
 
             this.checkTimer = "here";
 
-            if (!this.confirming && !this.confirmed) {
+            let togo;
+            if (this.isLoggedIn && !this.confirming && !this.confirmed) {
                 this.confirmed = await this.getConfirmationState();
+                togo = this.confirmed;
 
                 if (!this.confirmed && this.checkTimerCount++ < 100) {
                     this.checkTimer = setTimeout(() => this.waitForConfirmation(), 5000);

--- a/src/views/email/ConfirmEmail.vue
+++ b/src/views/email/ConfirmEmail.vue
@@ -1,0 +1,203 @@
+<!-- Confirms an email address - emails link to this page -->
+<template>
+  <div>
+    <div v-if="!loaded">{{ $t('ConfirmEmail.loading') }}</div>
+    <div v-else-if="confirming || confirmed">
+      <b-card class="confirmEmailMessageBox" title="Confirm Email">
+
+        <template v-if="confirmed">
+          <template v-if="confirmedAlready">
+            <p>Thanks. You have already confirmed your email address.</p>
+            <p>You can safely delete the email requesting your confirmation if you wish.</p>
+          </template>
+          <template v-else>
+            <p>Thank you for confirming your email with Morphic.</p>
+          </template>
+          <p>If you do not have Morphic installed on your computer yet, you can <b-link :to="{name:'Download'}">download Morphic here</b-link>.</p>
+        </template>
+
+        <template v-else-if="badToken">
+          <p>The link you clicked does not work.<br/>It might be a wrong link or a link that has expired.</p>
+          <!-- <p>Please check your link. If you think the confirmation link as expired, log into your Morphic account and see if your account is confirmed or not.</p> -->
+        </template>
+
+      </b-card>
+    </div>
+    <div v-else-if="!confirming" style="height: calc(100vh - 90px)">
+      <TwoColumnDialog
+              id="ConfirmEmailDialog"
+              visible="visible"
+              no-close
+              hide-backdrop
+              no-fade
+
+              size="lg"
+
+              dialog-class="confirmEmailDialog"
+
+              :title="$t('ConfirmEmail.dialog_title')"
+
+              :ok-title="$t('ConfirmEmail.ok_button')"
+
+              @ok="$event.promise = acceptInvite()"
+              @shown="dialogShown"
+      >
+        <template #form>
+
+          <p>Morphic just sent you an email with the subject "Welcome to Morphic."</p>
+
+          <p>When you confirm using the email, it will take you to a page where you can download Morphic.</p>
+
+
+        </template>
+
+        <template #buttons>
+          <b class="mt-4">Click the link in your email to confirm and continue.</b>
+        </template>
+
+        <template #info-heading>Didn't get email?</template>
+
+        <template #info>
+          <p id="EmailSteps">If you didn't get an email from Morphic, here are some steps you can try:</p>
+          <ul aria-describedby="EmailSteps">
+            <li>Wait a couple of minues to the email to arrive.</li>
+            <li>Check your junk or spam folder.</li>
+            <li>Go back and check your email address.</li>
+            <li>Press the "Resend email" button to get another copy.</li>
+          </ul>
+
+          <div class="text-center p-3">
+            <b-button variant="invert-dark" class="pl-4 pr-4">Resend Email</b-button>
+          </div>
+
+        </template>
+
+      </TwoColumnDialog>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+
+body:not(.isMobile) #ConfirmEmailDialog {
+  pointer-events: none;
+  & > * {
+    pointer-events: auto;
+  }
+}
+
+.confirmEmailMessageBox {
+  width: fit-content;
+  max-width: 500px;
+  margin: 5em auto;
+}
+
+</style>
+
+<script>
+
+import TwoColumnDialog from "@/components/dialogs/TwoColumnDialog";
+import { confirmEmail, getUser } from "@/services/userService";
+
+export default {
+    name: "ConfirmEmail",
+    components: {TwoColumnDialog},
+    data() {
+        return {
+            loaded: false,
+            message: null,
+            messageTitle: null,
+            confirmedAlready: undefined,
+            badToken: false,
+            confirmed: undefined,
+            checkTimer: undefined,
+            checkTimerCount: 0
+        };
+    },
+    props: {
+        signIn: Boolean,
+        confirmUserId: String,
+        token: String
+    },
+    async mounted() {
+        this.loaded = false;
+
+        if (this.confirming) {
+            // if (this.userId && this.confirmUserId !== this.userId) {
+            //     const logout = await this.showConfirm("The link you clicked is for a different user than who is currently logged in.", ["Sign out and confirm email", "Cancel"]);
+            //     if (logout) {
+            //         await this.$store.dispatch("logout");
+            //     } else {
+            //         setTimeout(() => this.$router.replace("/"), 500);
+            //         return;
+            //     }
+            // }
+
+            // Submit the token
+            try {
+                await confirmEmail(this.confirmUserId, this.token);
+            } catch (err) {
+                if (err.response?.data?.error === "invalid_token") {
+                    this.badToken = true;
+                    err.handled = true;
+                } else {
+                    throw err;
+                }
+            }
+
+            if (this.badToken) {
+                if (this.userId && this.userId === this.confirmUserId) {
+                    // Check if the user has already confirmed
+                    this.confirmedAlready = await this.getConfirmationState();
+                    this.confirmed = this.confirmedAlready;
+                }
+            } else {
+                this.confirmed = true;
+            }
+        } else {
+            await this.waitForConfirmation();
+        }
+
+        this.loaded = true;
+    },
+    computed: {
+        confirming: function () {
+            return this.confirmUserId && this.token;
+        }
+    },
+    methods: {
+
+        /**
+         * Called when the dialog has been shown.
+         */
+        dialogShown: function () {
+        },
+
+        getConfirmationState: async function () {
+            return !!(await getUser(this.userId)).email_verified;
+        },
+
+        /**
+         * Starts a timer that polls the confirmation state.
+         * @return {Promise<void>}
+         */
+        waitForConfirmation: async function () {
+            if (this.checkTimer === "here") {
+                return;
+            } else if (this.checkTimer) {
+                clearTimeout(this.checkTimer);
+            }
+
+            this.checkTimer = "here";
+
+            if (!this.confirming && !this.confirmed) {
+                this.confirmed = await this.getConfirmationState();
+
+                if (!this.confirmed && this.checkTimerCount++ < 100) {
+                    this.checkTimer = setTimeout(() => this.waitForConfirmation(), 5000);
+                }
+            }
+        }
+    }
+};
+</script>


### PR DESCRIPTION
The final stages of the new invitation flow.

Depends on https://github.com/raisingthefloor/morphic-api-server/pull/123

If the member uses a different email address to the invitation email, they are asked to confirm their email address.

![Confirm your email page](https://user-images.githubusercontent.com/1867587/132224580-01096a69-3247-4155-b61f-d837802ddb9f.png)

After confirming (if required), the download page is presented:

![Download page](https://user-images.githubusercontent.com/1867587/132233801-489688ae-050d-4b5b-9b73-346520aad81d.png)
