### PR TITLE
Removed the clipping of the gear icon on safari

### DIFF
--- a/src/components/side-panel/MembersList.vue
+++ b/src/components/side-panel/MembersList.vue
@@ -49,8 +49,9 @@
           <b-button variant="none" class="memberSettings whenExpanded"
                     @click="$emit('memberDetails', member)"
                     v-b-tooltip.hover="$t('MembersList.settings_tooltip', {name : member.displayName})"
-                    :aria-label="$t('MembersList.settings_tooltip', {name : member.displayName})">
-            <b-icon icon="gear-fill" variant="morphic-blue" scale="1.3" />
+                    :aria-label="$t('MembersList.settings_tooltip', {name : member.displayName})"
+                    style="font-size: 1.3em">
+            <b-icon icon="gear-fill" variant="morphic-blue" />
           </b-button>
         </div>
 


### PR DESCRIPTION
The turtle icon now looks like a gear, on safari.

Before:
![before](https://user-images.githubusercontent.com/1867587/132256420-e608e55b-f770-4beb-85a0-ed6b12350c50.png)

After:
![after](https://user-images.githubusercontent.com/1867587/132256362-bc8fb197-a1c5-41b6-ae5f-5244ea03fd40.png)
